### PR TITLE
Avoid DNS update if IP address didn't change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# configuration
+config/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,9 +1,0 @@
-class Config:
-    DNS_USER_ID = "SERVICE_ACCOUNT_NAME@YOUR_PROJECT.iam.gserviceaccount.com" # The GCP Service Account ID
-    DNS_KEY = "config/google.json" 		# The path to the JSON-key file (relative to the project's root)
-    DNS_PROJECT_NAME = "YOUR_PROJECT" 	# Your Google Cloud Platform project name
-
-# Example settings for creating an test.mydomain.com A record that points to your current IP
-    A_RECORD_TTL_SECONDS = 3600 	# The desired TTL for your DNS record
-    A_RECORD_NAME = "test" 		# The record name
-    A_RECORD_ZONE_NAME = "mydomain.com." # The domain zone name (usually the domain with an ending `.`)

--- a/update_dns.sh
+++ b/update_dns.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+python update_dns.py
+


### PR DESCRIPTION
- Saves the last IP address in the file `last_ip`
- Updates the DNS only if the current IP address is different
- Adds a bash wrapper which ensures that the `last_ip` file is written in the project directory